### PR TITLE
Updated version of timeoutParams()

### DIFF
--- a/src/masterchat.ts
+++ b/src/masterchat.ts
@@ -998,8 +998,8 @@ export class Masterchat extends EventEmitter {
   /**
    * Put user in timeout for 300 seconds
    */
-  public async timeout(channelId: string): Promise<void> {
-    const params = timeoutParams(channelId, this.cvPair());
+  public async timeout(channelId: string, timeoutLength: number = 300): Promise<void> {
+    const params = timeoutParams(channelId, this.cvPair(), timeoutLength);
 
     const res = await this.post<YTActionResponse>(
       Constants.EP_MOD,

--- a/src/masterchat.ts
+++ b/src/masterchat.ts
@@ -996,10 +996,17 @@ export class Masterchat extends EventEmitter {
   }
 
   /**
-   * Put user in timeout for 300 seconds
+   * Put user in timeout for *timeoutLength* seconds (default set to 300 seconds)
    */
-  public async timeout(channelId: string, timeoutLength: number = 300): Promise<void> {
-    const params = timeoutParams(channelId, this.cvPair(), timeoutLength);
+  public async timeout(
+    channelId: string,
+    timeoutLength: number = 300
+  ): Promise<void> {
+    const params = timeoutParams(
+      channelId,
+      this.cvPair(),
+      Math.min(Math.max(timeoutLength, 10), 86400)
+    );
 
     const res = await this.post<YTActionResponse>(
       Constants.EP_MOD,

--- a/src/masterchat.ts
+++ b/src/masterchat.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
 import { EventEmitter } from "events";
-import { AsyncIterator } from "iterator-helpers-polyfill";
 import { buildMeta } from "./api";
 import { buildAuthHeaders } from "./auth";
 import { parseAction } from "./chat";
@@ -600,10 +599,10 @@ export class Masterchat extends EventEmitter {
   /**
    * AsyncIterator API
    */
-  public iter(options?: IterateChatOptions): AsyncIterator<Action> {
-    return AsyncIterator.from<ChatResponse>(
-      this.iterate(options)
-    ).flatMap<Action>((action) => action.actions);
+  public async *iter(options?: IterateChatOptions): AsyncIterator<Action> {
+    for await (const response of this.iterate(options)) {
+      yield* response.actions;
+    }
   }
 
   /**

--- a/src/protobuf/assembler.ts
+++ b/src/protobuf/assembler.ts
@@ -129,13 +129,21 @@ export function removeMessageParams(
   );
 }
 
-export function timeoutParams(channelId: string, origin: CVPair): string {
+export function timeoutParams(
+  channelId: string,
+  origin: CVPair,
+  timeoutLength: number
+): string {
   return b64e(
     cc([
       ld(1, cvToken(origin)),
-      ld(6, ld(1, truc(channelId))),
-      vt(10, 2),
+      ld(6, [
+        ld(1, truc(channelId)),
+        ld(2, [vt(1, encv(BigInt(timeoutLength)))]),
+      ]),
+      vt(10, 1),
       vt(11, 1),
+      vt(14, 4),
     ]),
     B64Type.B2
   );


### PR DESCRIPTION
This pull request ([Ability to set timeoutLength in timeoutParams](https://github.com/HitomaruKonpaku/masterchat/commit/d02f025cc8dedefdcb57ef4fcd9aa83b34285fa4)) will enable masterchat to configure the number of seconds a user should be timed out (well tested!) when credentials are given. It is set to 300 seconds by default if not specified.